### PR TITLE
Add pdf attachment support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "jspdf": "^1.5.3",
+    "pdf-lib": "^1.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/components/BillForm.js
+++ b/src/components/BillForm.js
@@ -151,7 +151,7 @@ const BillForm = (props) => {
         fluid
         name="attachments"
         type="file"
-        accept="image/*"
+        accept="application/pdf, image/*"
         multiple
         onChange={handleFileChange}
       />

--- a/src/utils/file-reader.js
+++ b/src/utils/file-reader.js
@@ -1,0 +1,36 @@
+export const fileTypeFromDataURL = (dataURL) => {
+  return dataURL.split(';')[0].split(':')[1];
+};
+
+export const readFile = (file) => {
+  const reader = new FileReader();
+
+  return new Promise((resolve, reject) => {
+    reader.onerror = () => {
+      reader.abort();
+      reject(new DOMException('Problem parsing input file.'));
+    };
+
+    reader.onload = () => {
+      resolve(reader.result);
+    };
+
+    reader.readAsDataURL(file);
+  });
+};
+
+export const loadImage = (fileDataUrl) => {
+  const image = new Image();
+
+  return new Promise((resolve, reject) => {
+    image.onerror = () => {
+      reject(new DOMException('Problem loading image from FileLoader.'));
+    };
+
+    image.onload = () => {
+      resolve(image);
+    };
+
+    image.src = fileDataUrl;
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,14 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@pdf-lib/standard-fonts@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-0.0.4.tgz#49fffa97fe1a5fff9b8b60fd9decf79b10bd0982"
+  integrity sha512-2pg8hXnChVAF6aSFraXtwB0cx/AgE15FvuLJbdPJSq9LYp1xMp0lapH4+t1HsdD9cA05rnWYLqlEBwS4YK1jLg==
+  dependencies:
+    base64-arraybuffer "^0.1.5"
+    pako "^1.0.6"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -8809,7 +8817,7 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@~1.0.5:
+pako@^1.0.10, pako@^1.0.6, pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
@@ -8988,6 +8996,16 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pdf-lib@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.2.1.tgz#c50bc7ed586cbc366df32f9487c792cb3cc16af2"
+  integrity sha512-emphLPyAtov+ylhJkXQ/xx/Hbsz6QxzHOdqzcMyMz7aGPe3aHcD5HWB0ly8A3TZy8HqAiMrTswXgQ6hAsq8vQQ==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^0.0.4"
+    pako "^1.0.10"
+    png-ts "^0.0.3"
+    tslib "^1.10.0"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -9085,6 +9103,13 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+png-ts@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/png-ts/-/png-ts-0.0.3.tgz#497fa90f13b9a2cdcd5a457cb1c28ab3c68ec145"
+  integrity sha512-Qwn3yMfbrbaN86QjrDAqD1UVJc4AV4hvBCx5Dv9libLd6D20xKtgOFs/UcvD0nnjxWlgS12kEVWCDFd9ZtwB+g==
+  dependencies:
+    pako "^1.0.6"
 
 pnp-webpack-plugin@1.5.0:
   version "1.5.0"
@@ -11834,7 +11859,7 @@ ts-pnp@1.1.5, ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
   integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
Request for pdf attachments is in issue #3. This is implemented with `pdf-lib`. Creating documents with `pdf-lib` turned out to be more complicated than with `jspdf` so new pages are still created with `jspdf` and pages are merged with `pdf-lib`.